### PR TITLE
Update Florian Rivoal's AB term

### DIFF
--- a/members.json
+++ b/members.json
@@ -1125,7 +1125,7 @@
 			},
 			{
 				"start": "2024-07-01",
-				"end": "2026-06-30",
+				"end": "2025-01-20",
 				"type": "elected",
 				"affiliation": "W3C Invited Expert"
 			}


### PR DESCRIPTION
Florian Rivoal stepped down from the AB on [2025-01-20](https://lists.w3.org/Archives/Member/w3c-ac-forum/2025JanMar/0014.html).