### PR TITLE
add Anqi chair as of 2024-12-05

### DIFF
--- a/members.json
+++ b/members.json
@@ -1374,7 +1374,7 @@
 			{
 				"start": "2024-12-05",
 				"chair": "true",
-				"type": "staff-contact"
+				"type": "appointed"
 			}
 		]
 	}

--- a/members.json
+++ b/members.json
@@ -1367,6 +1367,16 @@
 				"affiliation": "The News Corporation"
 			}
 		]
+	},
+	{
+		"name": "Anqi Li",
+		"term": [
+			{
+				"start": "2024-12-05",
+				"chair": "true",
+				"type": "staff-contact"
+			}
+		]
 	}
 
 

--- a/members.json
+++ b/members.json
@@ -1374,7 +1374,7 @@
 			{
 				"start": "2024-12-05",
 				"chair": "true",
-				"type": "appointed"
+				"type": "staff-contact"
 			}
 		]
 	}


### PR DESCRIPTION
Add Anqi as chair as of 2024-12-05 https://www.w3.org/2024/12/05-ab-minutes.html#9f62 probably needs additional change to indicate @cwilso stepping down as chair but not quite sure how to represent that mid-elected-term